### PR TITLE
fix panic when command empty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
         while let Some(command) = commands.next() {
             // everything after the first whitespace character is interpreted as args to the command
             let mut parts = command.trim().split_whitespace();
-            let command = parts.next().unwrap();
+            let command = parts.next().unwrap_or("");
             let args = parts;
 
             match command {


### PR DESCRIPTION
Fixes the panic when parsing an empty command, say when hitting enter at the prompt or when running `a |  | b` (note the two spaces).